### PR TITLE
Android: Support for 16 KB page sizes

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.3.0
+version: 2.4.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-review-dialog
@@ -15,4 +15,4 @@ name: titanium-review-dialog
 moduleid: ti.reviewdialog
 guid: e2e648b3-d410-45a9-a95e-100965904f91
 platform: android
-minsdk: 9.0.0
+minsdk: 12.8.0


### PR DESCRIPTION
- updated `minsdk` to `12.8.0` according to https://github.com/tidev/titanium-sdk/issues/14239 so the module can be built with SDK 12.8.1
- using the [script](https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh) `check_elf_alignment.sh` then results in:
```
.../lib/arm64-v8a/libti.reviewdialog.so: ALIGNED (2**14)
.../lib/x86_64/libti.reviewdialog.so: ALIGNED (2**14)
```